### PR TITLE
Fetch all "README" variants and only render the content as markdown if it is markdown

### DIFF
--- a/pages/packages/[user]/[...projectName].tsx
+++ b/pages/packages/[user]/[...projectName].tsx
@@ -155,23 +155,23 @@ export async function getServerSideProps({ params: { user, projectName } }: { pa
 
   // ------------ Get the correct readme.md ---------------
   const fetchReadmeContent = async (repo: Repo) => {
+    const extensions = ["", "txt", "md"] as const;
     const defaultBranch = repo.default_branch || 'master';
-    const extensions = ["", ".txt", ".md"];
     const readmeCasing = ["readme", "README"];
 
     for (let ext of extensions) {
       for (let readmeCase of readmeCasing) {
-        const url = `https://raw.githubusercontent.com/${repo.full_name}/${defaultBranch}/${readmeCase}${ext}`
+        const url = `https://raw.githubusercontent.com/${repo.full_name}/${defaultBranch}/${readmeCase}${ext && `.${ext}`}`
         let response = await fetch(url, { method: "HEAD" });
 
         if (response.ok) {
            response = await fetch(url);
-           return response.text();
+           return { content: await response.text(), ext: ext };
         }
       }
     }
 
-    return "404";
+    return { content: "404", ext: "" };
   };
 
   // ----------- Fetch the readme and tags --------------
@@ -191,7 +191,7 @@ export async function getServerSideProps({ params: { user, projectName } }: { pa
     contentIsCorrect: true,
     name: repository.name,
     full_name: repository.full_name,
-    readme_content: await marked(readmeContent),
+    readme_content: readmeContent.ext === "md" ? await marked(readmeContent.content) : `<pre style="padding: 0 !important; border: 0 !important;">${readmeContent.content}</pre>`,
     created_at: repository.created_at,
     description: repository.description,
     tags_url: repository.tags_url,

--- a/pages/packages/[user]/[...projectName].tsx
+++ b/pages/packages/[user]/[...projectName].tsx
@@ -156,14 +156,19 @@ export async function getServerSideProps({ params: { user, projectName } }: { pa
   // ------------ Get the correct readme.md ---------------
   const fetchReadmeContent = async (repo: Repo) => {
     const defaultBranch = repo.default_branch || 'master';
-    const readmeUrls = [
-      `https://raw.githubusercontent.com/${repo.full_name}/${defaultBranch}/README.md`,
-      `https://raw.githubusercontent.com/${repo.full_name}/${defaultBranch}/readme.md`
-    ];
+    const extensions = ["", ".txt", ".md"];
+    const readmeCasing = ["readme", "README"];
 
-    for (let url of readmeUrls) {
-      const response = await fetch(url);
-      if (response.ok) return response.text();
+    for (let ext of extensions) {
+      for (let readmeCase of readmeCasing) {
+        const url = `https://raw.githubusercontent.com/${repo.full_name}/${defaultBranch}/${readmeCase}${ext}`
+        let response = await fetch(url, { method: "HEAD" });
+
+        if (response.ok) {
+           response = await fetch(url);
+           return response.text();
+        }
+      }
     }
 
     return "404";


### PR DESCRIPTION
**Describe the pull request**
Fetch all "README" variants and only render the content as markdown if it is markdown

**Additional context**
![image](https://github.com/user-attachments/assets/021a8e4d-2230-4416-9605-d1f24d206c76)
Figure: Fetches "README" and renders the text as text, not md.
