### PR TITLE
Update repoListCompressor.zig

### DIFF
--- a/scripts/repoListCompressor.zig
+++ b/scripts/repoListCompressor.zig
@@ -39,10 +39,10 @@ const topic_urls = [3][5][]const u8{
     // Gui
     .{
         "https://api.github.com/repos/capy-ui/capy",
+        "https://api.github.com/repos/webui-dev/zig-webui",
         "https://api.github.com/repos/david-vanderson/dvui",
         "https://api.github.com/repos/kassane/qml_zig",
         "https://api.github.com/repos/MoAlyousef/zfltk",
-        "https://api.github.com/repos/Aransentin/ZWL",
     },
 };
 


### PR DESCRIPTION
Replace ZWL with zig-webui
In fact, zwl is currently unavailable
Already sorted by number of stars

